### PR TITLE
SystemUI: Fix Keyguard view being stretched for non-FOD devices

### DIFF
--- a/packages/SystemUI/res-keyguard/layout/keyguard_host_view.xml
+++ b/packages/SystemUI/res-keyguard/layout/keyguard_host_view.xml
@@ -34,7 +34,6 @@
         android:id="@+id/keyguard_security_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        androidprv:layout_maxHeight="@dimen/keyguard_security_max_height"
         android:clipChildren="false"
         android:clipToPadding="false"
         android:padding="0dp"

--- a/packages/SystemUI/res-keyguard/layout/keyguard_pattern_view.xml
+++ b/packages/SystemUI/res-keyguard/layout/keyguard_pattern_view.xml
@@ -26,11 +26,10 @@
     android:id="@+id/keyguard_pattern_view"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:clipChildren="false"
     android:clipToPadding="false"
     androidprv:layout_maxWidth="@dimen/keyguard_security_width"
-    androidprv:layout_maxHeight="@dimen/keyguard_security_height"
     android:gravity="center_horizontal">
 
     <FrameLayout
@@ -61,13 +60,20 @@
                 android:clipChildren="false"
                 android:clipToPadding="false" />
 
-          <include layout="@layout/keyguard_eca"
-              android:id="@+id/keyguard_selector_fade_container"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:orientation="vertical"
-              android:layout_gravity="bottom|center_horizontal"
-              android:gravity="center_horizontal" />
+            <View
+                android:id="@+id/fod_view"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/keyguard_security_fod_view_margin"
+                android:layout_gravity="bottom"
+                android:visibility="gone" />
+
+            <include layout="@layout/keyguard_eca"
+                android:id="@+id/keyguard_selector_fade_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_gravity="bottom|center_horizontal"
+                android:gravity="center_horizontal" />
         </LinearLayout>
     </FrameLayout>
 

--- a/packages/SystemUI/res-keyguard/layout/keyguard_pin_view.xml
+++ b/packages/SystemUI/res-keyguard/layout/keyguard_pin_view.xml
@@ -22,17 +22,15 @@
         xmlns:androidprv="http://schemas.android.com/apk/res-auto"
         android:id="@+id/keyguard_pin_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         androidprv:layout_maxWidth="@dimen/keyguard_security_width"
-        androidprv:layout_maxHeight="@dimen/keyguard_security_max_height"
         android:orientation="vertical"
         >
     <LinearLayout
             android:id="@+id/container"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
+            android:layout_height="@dimen/keyguard_security_height"
             android:orientation="vertical"
-            android:layout_weight="1"
             android:layoutDirection="ltr"
             >
         <com.android.keyguard.AlphaOptimizedRelativeLayout
@@ -192,6 +190,14 @@
                     />
         </LinearLayout>
     </LinearLayout>
+
+    <View
+        android:id="@+id/fod_view"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/keyguard_security_fod_view_margin"
+        android:layout_gravity="bottom"
+        android:visibility="gone" />
+
     <include layout="@layout/keyguard_eca"
              android:id="@+id/keyguard_selector_fade_container"
              android:layout_width="match_parent"

--- a/packages/SystemUI/res-keyguard/values-sw540dp-port/dimens.xml
+++ b/packages/SystemUI/res-keyguard/values-sw540dp-port/dimens.xml
@@ -20,5 +20,5 @@
 <resources>
     <!-- Height of the sliding KeyguardSecurityContainer
         (includes 2x keyguard_security_view_top_margin) -->
-    <dimen name="keyguard_security_height">690dp</dimen>
+    <dimen name="keyguard_security_height">550dp</dimen>
 </resources>

--- a/packages/SystemUI/res-keyguard/values-sw720dp/dimens.xml
+++ b/packages/SystemUI/res-keyguard/values-sw720dp/dimens.xml
@@ -20,7 +20,7 @@
 
     <!-- Height of the sliding KeyguardSecurityContainer
          (includes 2x keyguard_security_view_top_margin) -->
-    <dimen name="keyguard_security_height">610dp</dimen>
+    <dimen name="keyguard_security_height">470dp</dimen>
 
     <dimen name="widget_big_font_size">100dp</dimen>
 </resources>

--- a/packages/SystemUI/res-keyguard/values/dimens.xml
+++ b/packages/SystemUI/res-keyguard/values/dimens.xml
@@ -27,15 +27,11 @@
 
     <!-- Height of the sliding KeyguardSecurityContainer
          (includes 2x keyguard_security_view_top_margin) -->
-    <dimen name="keyguard_security_height">560dp</dimen>
+    <dimen name="keyguard_security_height">420dp</dimen>
 
     <!-- Max Height of the sliding KeyguardSecurityContainer
          (includes 2x keyguard_security_view_top_margin) -->
-    <dimen name="keyguard_security_max_height">590dp</dimen>
-
-    <!-- The margin between Emergency Carrier area and pattern/pin
-         view to incorporate the FOD icon -->
-    <dimen name="keyguard_security_fod_view_margin">140dp</dimen>
+    <dimen name="keyguard_security_max_height">450dp</dimen>
 
     <!-- Margin around the various security views -->
     <dimen name="keyguard_security_view_top_margin">8dp</dimen>

--- a/packages/SystemUI/res-keyguard/values/pa_dimens.xml
+++ b/packages/SystemUI/res-keyguard/values/pa_dimens.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2020 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+    <!-- The margin between Emergency Carrier area and pattern/pin
+         view to incorporate the FOD icon -->
+    <dimen name="keyguard_security_fod_view_margin">140dp</dimen>
+</resources>

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardSecurityContainer.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardSecurityContainer.java
@@ -32,7 +32,6 @@ import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.VelocityTracker;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.ViewConfiguration;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
@@ -102,7 +101,6 @@ public class KeyguardSecurityContainer extends FrameLayout implements KeyguardSe
     private int mActivePointerId = -1;
     private boolean mIsDragging;
     private float mStartTouchY = -1;
-    private final int mFODmargin;
 
     // Used to notify the container when something interesting happens.
     public interface SecurityCallback {
@@ -138,8 +136,6 @@ public class KeyguardSecurityContainer extends FrameLayout implements KeyguardSe
             SystemUIFactory.getInstance().getRootComponent());
         mUnlockMethodCache = UnlockMethodCache.getInstance(context);
         mViewConfiguration = ViewConfiguration.get(context);
-        mFODmargin = mContext.getResources().getDimensionPixelSize(
-            R.dimen.keyguard_security_fod_view_margin);
     }
 
     public void setSecurityCallback(SecurityCallback callback) {
@@ -302,14 +298,14 @@ public class KeyguardSecurityContainer extends FrameLayout implements KeyguardSe
             if (DEBUG) Log.v(TAG, "inflating id = " + layoutId);
             View v = mInjectionInflationController.injectable(inflater)
                     .inflate(layoutId, mSecurityViewFlipper, false);
-            View eca = v.findViewById(R.id.keyguard_selector_fade_container);
-            if (eca != null && hasInDisplayFingerprint() &&
-                    (securityMode == SecurityMode.Pattern
-                        || securityMode == SecurityMode.PIN)) {
-                ViewGroup.MarginLayoutParams lp = (ViewGroup.MarginLayoutParams)
-                            eca.getLayoutParams();
-                lp.setMargins(lp.leftMargin, mFODmargin, lp.rightMargin,
-                            lp.bottomMargin);
+            View fod_view = v.findViewById(R.id.fod_view);
+            if (fod_view != null) {
+                if (hasInDisplayFingerprint() &&
+                        mUpdateMonitor.isUnlockWithFingerprintPossible()) {
+                    fod_view.setVisibility(View.VISIBLE);
+                } else {
+                    fod_view.setVisibility(View.GONE);
+                }
             }
             mSecurityViewFlipper.addView(v);
             updateSecurityView(v);
@@ -597,7 +593,6 @@ public class KeyguardSecurityContainer extends FrameLayout implements KeyguardSe
         mCurrentSecurityView = newView;
         mSecurityCallback.onSecurityModeChanged(securityMode,
                 securityMode != SecurityMode.None && newView.needsInput());
-        mUpdateMonitor.setSecurityMode(securityMode);
     }
 
     private KeyguardSecurityViewFlipper getFlipper() {

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitor.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitor.java
@@ -96,7 +96,6 @@ import com.android.internal.telephony.PhoneConstants;
 import com.android.internal.telephony.TelephonyIntents;
 import com.android.internal.util.Preconditions;
 import com.android.internal.widget.LockPatternUtils;
-import com.android.keyguard.KeyguardSecurityModel.SecurityMode;
 import com.android.settingslib.WirelessUtils;
 import com.android.systemui.R;
 import com.android.systemui.shared.system.ActivityManagerWrapper;
@@ -259,7 +258,6 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
     private int mFingerprintRunningState = BIOMETRIC_STATE_STOPPED;
     private int mFaceRunningState = BIOMETRIC_STATE_STOPPED;
     private LockPatternUtils mLockPatternUtils;
-    private SecurityMode mCurrentSecurityMode = SecurityMode.Invalid;
     private final IDreamManager mDreamManager;
     private boolean mIsDreaming;
     private final DevicePolicyManager mDevicePolicyManager;
@@ -927,14 +925,6 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
                 cb.onFaceUnlockStateChanged(running, userId);
             }
         }
-    }
-
-    public SecurityMode getSecurityMode() {
-        return mCurrentSecurityMode;
-    }
-
-    public void setSecurityMode(SecurityMode securityMode) {
-        mCurrentSecurityMode = securityMode;
     }
 
     public boolean isFaceUnlockRunning(int userId) {
@@ -1826,6 +1816,11 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
                     mFaceAuthenticationCallback, null, userId);
             setFaceRunningState(BIOMETRIC_STATE_RUNNING);
         }
+    }
+
+    public boolean isUnlockWithFingerprintPossible() {
+        final int userId = getCurrentUser();
+        return isUnlockWithFingerprintPossible(userId);
     }
 
     /**

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -16,6 +16,7 @@
 
 package com.android.systemui.biometrics;
 
+import android.app.admin.DevicePolicyManager;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -44,6 +45,7 @@ import android.widget.ImageView;
 import com.android.keyguard.KeyguardUpdateMonitor;
 import com.android.keyguard.KeyguardUpdateMonitorCallback;
 import com.android.keyguard.KeyguardSecurityModel.SecurityMode;
+import com.android.internal.widget.LockPatternUtils;
 import com.android.systemui.R;
 
 import vendor.pa.biometrics.fingerprint.inscreen.V1_0.IFingerprintInscreen;
@@ -81,6 +83,8 @@ public class FODCircleView extends ImageView implements OnTouchListener {
     private boolean mIsViewAdded;
 
     private Handler mHandler;
+
+    private LockPatternUtils mLockPatternUtils;
 
     private Timer mBurnInProtectionTimer;
 
@@ -180,10 +184,7 @@ public class FODCircleView extends ImageView implements OnTouchListener {
         public void onKeyguardBouncerChanged(boolean isBouncer) {
             mIsBouncer = isBouncer;
             if (mUpdateMonitor.isFingerprintDetectionRunning()) {
-                final SecurityMode sec = mUpdateMonitor.getSecurityMode();
-                final boolean maybeShow = sec == SecurityMode.Pattern ||
-                        sec == SecurityMode.PIN;
-                if (maybeShow || !mIsBouncer) {
+                if (isPinOrPattern(mUpdateMonitor.getCurrentUser()) || !isBouncer) {
                     show();
                 } else {
                     hide();
@@ -264,6 +265,8 @@ public class FODCircleView extends ImageView implements OnTouchListener {
         mUpdateMonitor.registerCallback(mMonitorCallback);
 
         mDisplayManager = context.getSystemService(DisplayManager.class);
+
+        mLockPatternUtils = new LockPatternUtils(mContext);
     }
 
     @Override
@@ -516,6 +519,20 @@ public class FODCircleView extends ImageView implements OnTouchListener {
         } catch (IllegalArgumentException e) {
             // do nothing
         }
+    }
+
+    private boolean isPinOrPattern(int userId) {
+        int passwordQuality = mLockPatternUtils.getActivePasswordQuality(userId);
+        switch (passwordQuality) {
+            // PIN
+            case DevicePolicyManager.PASSWORD_QUALITY_NUMERIC:
+            case DevicePolicyManager.PASSWORD_QUALITY_NUMERIC_COMPLEX:
+            // Pattern
+            case DevicePolicyManager.PASSWORD_QUALITY_SOMETHING:
+                return true;
+        }
+
+        return false;
     }
 
     private class BurnInProtectionTask extends TimerTask {


### PR DESCRIPTION
* devices can overlay the default FOD view height of 140dp in their dt
* remove the FOD space when no fingerprint is registered even on FOD devices
* this is a partial revert of e45c288d9496568593fd7516716c753d4f0f361d

Signed-off-by: rituj <ritujbeniwal@gmail.com>
Change-Id: Ifdc80c400afdc0be865910979eb82501561eaf72